### PR TITLE
Allow Struct Field Type to be overriden if ts_type tag present

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -358,12 +358,24 @@ func (t *typeScriptClassBuilder) AddSimpleField(fieldName string, field reflect.
 
 func (t *typeScriptClassBuilder) AddStructField(fieldName string, field reflect.StructField) {
 	fieldType := field.Type.Name()
+	customTSType := field.Tag.Get(tsType)
+
+	if len(customTSType) > 0 {
+		fieldType = customTSType
+	}
+
 	t.fields += fmt.Sprintf("%s%s: %s;\n", t.indent, fieldName, fieldType)
 	t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? %s.createFrom(source[\"%s\"]) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldType, fieldName)
 }
 
 func (t *typeScriptClassBuilder) AddArrayOfStructsField(fieldName string, field reflect.StructField, arrayDepth int) {
 	fieldType := field.Type.Elem().Name()
+	customTSType := field.Tag.Get(tsType)
+
+	if len(customTSType) > 0 {
+		fieldType = customTSType
+	}
+
 	t.fields += fmt.Sprintf("%s%s: %s%s;\n", t.indent, fieldName, fieldType, strings.Repeat("[]", arrayDepth))
 	t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? source[\"%s\"].map(function(element: any) { return %s.createFrom(element); }) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldName, fieldType)
 }

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -361,11 +361,13 @@ func (t *typeScriptClassBuilder) AddStructField(fieldName string, field reflect.
 	customTSType := field.Tag.Get(tsType)
 
 	if len(customTSType) > 0 {
-		fieldType = customTSType
+		t.fields += fmt.Sprintf("%s%s: %s;\n", t.indent, fieldName, fieldType)
+		t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"];\n", t.indent, t.indent, fieldName, fieldName)
+	} else {
+		t.fields += fmt.Sprintf("%s%s: %s;\n", t.indent, fieldName, fieldType)
+		t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? %s.createFrom(source[\"%s\"]) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldType, fieldName)
 	}
 
-	t.fields += fmt.Sprintf("%s%s: %s;\n", t.indent, fieldName, fieldType)
-	t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? %s.createFrom(source[\"%s\"]) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldType, fieldName)
 }
 
 func (t *typeScriptClassBuilder) AddArrayOfStructsField(fieldName string, field reflect.StructField, arrayDepth int) {
@@ -373,9 +375,10 @@ func (t *typeScriptClassBuilder) AddArrayOfStructsField(fieldName string, field 
 	customTSType := field.Tag.Get(tsType)
 
 	if len(customTSType) > 0 {
-		fieldType = customTSType
+		t.fields += fmt.Sprintf("%s%s: %s%s;\n", t.indent, fieldName, customTSType, strings.Repeat("[]", arrayDepth))
+		t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"];\n", t.indent, t.indent, fieldName, fieldName)
+	} else {
+		t.fields += fmt.Sprintf("%s%s: %s%s;\n", t.indent, fieldName, fieldType, strings.Repeat("[]", arrayDepth))
+		t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? source[\"%s\"].map(function(element: any) { return %s.createFrom(element); }) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldName, fieldType)
 	}
-
-	t.fields += fmt.Sprintf("%s%s: %s%s;\n", t.indent, fieldName, fieldType, strings.Repeat("[]", arrayDepth))
-	t.createFromMethodBody += fmt.Sprintf("%s%sresult.%s = source[\"%s\"] ? source[\"%s\"].map(function(element: any) { return %s.createFrom(element); }) : null;\n", t.indent, t.indent, fieldName, fieldName, fieldName, fieldType)
 }


### PR DESCRIPTION
Ran into this on current project. Use case involved having a custom type i.e.

```go
type MSTime struct{
    time.Time 
}
//used as

type SomeStruct stuct{
    Time MSTime `json:"time" ts_type:"number"`
}
```
With a custom MarshallJSON/UnmarshalJSON that converted the time to/from epoch ms timestamp. So I wanted it to appear as a number type in my .ts files not a 'MSTime' Class. 
