### PR TITLE
Enable the addition of custom imports on the generated TS file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,41 @@
+name: Go
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: 'master'
+
+jobs:
+
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: |
+        cd tscriptify
+        go build -v .
+
+    - name: Test
+      run: |
+        cd typescriptify
+        go test -v .

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Use the command line tool:
 tscriptify -package=package/with/your/models -target=target_ts_file.ts Model1 Model2
 ```
 
+If you need to import a custom type in Typescript, you can pass the import string:
+
+```
+tscriptify -package=package/with/your/models -target=target_ts_file.ts -import="import { Decimal } from 'decimal.js'" Model1 Model2
+```
+
 If all your structs are in one file, you can convert them with:
 
 ```

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If you use golang JSON structs as responses from your API, you may want to have 
 
 ```golang
 converter := typescriptify.New()
-converter.Prefix("API_")
+converter.Prefix = "API_"
 converter.Add(Person{})
 ```
 
@@ -221,6 +221,15 @@ export class Data {
 ```
 
 In this case, you should always use `Data.createFrom(json)` instead of just casting `<Data>json`.
+
+If you use a custom type that has to be imported, you can do the following:
+
+```golang
+converter := typescriptify.New()
+converter.CustomImports = append(converter.CustomImports, "import Decimal from 'decimal.js'")
+```
+
+This will put your import on top of the generated file.
 
 ## Enums
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ If you use a custom type that has to be imported, you can do the following:
 
 ```golang
 converter := typescriptify.New()
-converter.CustomImports = append(converter.CustomImports, "import Decimal from 'decimal.js'")
+converter.AddImport("import Decimal from 'decimal.js'")
 ```
 
 This will put your import on top of the generated file.

--- a/tscriptify/main.go
+++ b/tscriptify/main.go
@@ -40,7 +40,7 @@ func main() {
 {{ end }}
 {{ range .Structs }}	t.Add({{ . }}{})
 {{ end }}
-{{ range .CustomImports }}	t.AddImport({{ . }})
+{{ range .CustomImports }}	t.AddImport("{{ . }}")
 {{ end }}
 	err := t.ConvertToFile("{{ .TargetFile }}")
 	if err != nil {

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -246,7 +246,7 @@ func (t TypeScriptify) ConvertToFile(fileName string) error {
 			f.WriteString(cimport + "\n")
 		}
 
-		f.WriteString("\n\n")
+		f.WriteString("\n")
 	}
 	f.WriteString(converted)
 	if err != nil {

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -25,6 +25,7 @@ type TypeScriptify struct {
 	BackupDir        string // If empty no backup
 	DontExport       bool
 	CreateInterface  bool
+	CustomImports    []string
 
 	golangTypes []reflect.Type
 	enumTypes   []reflect.Type
@@ -238,6 +239,15 @@ func (t TypeScriptify) ConvertToFile(fileName string) error {
 	}
 
 	f.WriteString("/* Do not change, this code is generated from Golang structs */\n\n")
+	if len(t.CustomImports) > 0 {
+		// Put in the custom imports, i.e.: `import Decimal from 'decimal.js'`
+		// TODO: Check for repeating custom imports
+		for _, cimport := range t.CustomImports {
+			f.WriteString(cimport)
+		}
+
+		f.WriteString("\n\n")
+	}
 	f.WriteString(converted)
 	if err != nil {
 		return err

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -134,6 +134,13 @@ func (t *TypeScriptify) Convert(customCode map[string]string) (string, error) {
 	t.alreadyConverted = make(map[reflect.Type]bool)
 
 	result := ""
+	if len(t.customImports) > 0 {
+		// Put the custom imports, i.e.: `import Decimal from 'decimal.js'`
+		for _, cimport := range t.customImports {
+			result += cimport + "\n"
+		}
+	}
+
 	for _, typeof := range t.enumTypes {
 
 		typeScriptCode, err := t.convertEnum(typeof, t.enumValues[typeof])
@@ -239,15 +246,7 @@ func (t TypeScriptify) ConvertToFile(fileName string) error {
 	}
 
 	f.WriteString("/* Do not change, this code is generated from Golang structs */\n\n")
-	if len(t.customImports) > 0 {
-		// Put in the custom imports, i.e.: `import Decimal from 'decimal.js'`
-		// TODO: Check for repeating custom imports
-		for _, cimport := range t.customImports {
-			f.WriteString(cimport + "\n")
-		}
 
-		f.WriteString("\n")
-	}
 	f.WriteString(converted)
 	if err != nil {
 		return err

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -25,7 +25,7 @@ type TypeScriptify struct {
 	BackupDir        string // If empty no backup
 	DontExport       bool
 	CreateInterface  bool
-	CustomImports    []string
+	customImports    []string
 
 	golangTypes []reflect.Type
 	enumTypes   []reflect.Type
@@ -239,10 +239,10 @@ func (t TypeScriptify) ConvertToFile(fileName string) error {
 	}
 
 	f.WriteString("/* Do not change, this code is generated from Golang structs */\n\n")
-	if len(t.CustomImports) > 0 {
+	if len(t.customImports) > 0 {
 		// Put in the custom imports, i.e.: `import Decimal from 'decimal.js'`
 		// TODO: Check for repeating custom imports
-		for _, cimport := range t.CustomImports {
+		for _, cimport := range t.customImports {
 			f.WriteString(cimport + "\n")
 		}
 
@@ -404,6 +404,16 @@ func (t *TypeScriptify) convertType(typeOf reflect.Type, customCode map[string]s
 	result += "}"
 
 	return result, nil
+}
+
+func (t *TypeScriptify) AddImport(i string) {
+	for _, cimport := range t.customImports {
+		if cimport == i {
+			return
+		}
+	}
+
+	t.customImports = append(t.customImports, i)
 }
 
 type typeScriptClassBuilder struct {

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -243,7 +243,7 @@ func (t TypeScriptify) ConvertToFile(fileName string) error {
 		// Put in the custom imports, i.e.: `import Decimal from 'decimal.js'`
 		// TODO: Check for repeating custom imports
 		for _, cimport := range t.CustomImports {
-			f.WriteString(cimport)
+			f.WriteString(cimport + "\n")
 		}
 
 		f.WriteString("\n\n")

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -62,6 +62,36 @@ export class Person {
 	testConverter(t, converter, desiredResult)
 }
 
+func TestTypescriptifyWithCustomImports(t *testing.T) {
+	converter := New()
+
+	converter.AddType(reflect.TypeOf(Person{}))
+	converter.CreateFromMethod = false
+	converter.BackupDir = ""
+	converter.AddImport("import { Decimal } from 'decimal.js'")
+
+	desiredResult := `
+import { Decimal } from 'decimal.js'
+
+export class Dummy {
+        something: string;
+}
+export class Address {
+        duration: number;
+        text?: string;
+}
+export class Person {
+        name: string;
+        nicknames: string[];
+		addresses: Address[];
+		address: Address;
+		metadata: {[key:string]:string};
+		friends: Person[];
+        a: Dummy;
+}`
+	testConverter(t, converter, desiredResult)
+}
+
 func TestTypescriptifyWithInstances(t *testing.T) {
 	converter := New()
 


### PR DESCRIPTION
This makes it easier to have the imports from the get-go on the TS file instead of having to manually edit the output.

fixes #31 