### PR TITLE
Add `?` to field name if it's a pointer type

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -304,7 +304,8 @@ func (t *TypeScriptify) convertType(typeOf reflect.Type, customCode map[string]s
 
 	fields := deepFields(typeOf)
 	for _, field := range fields {
-		if field.Type.Kind() == reflect.Ptr {
+		isPtr := field.Type.Kind() == reflect.Ptr
+		if isPtr {
 			field.Type = field.Type.Elem()
 		}
 		jsonTag := field.Tag.Get("json")
@@ -314,13 +315,18 @@ func (t *TypeScriptify) convertType(typeOf reflect.Type, customCode map[string]s
 			if len(jsonTagParts) > 0 {
 				jsonFieldName = strings.Trim(jsonTagParts[0], t.Indent)
 			}
+			hasOmitEmpty := false
 			for _, t := range jsonTagParts {
 				if t == "" {
 					break
 				}
 				if t == "omitempty" {
-					jsonFieldName = fmt.Sprintf("%s?", jsonFieldName)
+					hasOmitEmpty = true
+					break
 				}
+			}
+			if isPtr || hasOmitEmpty {
+				jsonFieldName = fmt.Sprintf("%s?", jsonFieldName)
 			}
 		}
 		if len(jsonFieldName) > 0 && jsonFieldName != "-" {

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -54,7 +54,7 @@ export class Person {
         name: string;
         nicknames: string[];
 		addresses: Address[];
-		address: Address;
+		address?: Address;
 		metadata: {[key:string]:string};
 		friends: Person[];
         a: Dummy;
@@ -82,7 +82,7 @@ class Person {
         name: string;
         nicknames: string[];
 		addresses: Address[];
-		address: Address;
+		address?: Address;
 		metadata: {[key:string]:string};
 		friends: Person[];
         a: Dummy;
@@ -111,7 +111,7 @@ interface Person {
         name: string;
         nicknames: string[];
 		addresses: Address[];
-		address: Address;
+		address?: Address;
 		metadata: {[key:string]:string};
 		friends: Person[];
         a: Dummy;
@@ -138,7 +138,7 @@ export class Person {
         name: string;
 		nicknames: string[];
 		addresses: Address[];
-		address: Address;
+		address?: Address;
 		metadata: {[key:string]:string};
 		friends: Person[];
         a: Dummy;
@@ -186,7 +186,7 @@ class test_Person_test {
     name: string;
     nicknames: string[];
     addresses: test_Address_test[];
-    address: test_Address_test;
+    address?: test_Address_test;
     metadata: {[key:string]:string};
     friends: test_Person_test[];
     a: test_Dummy_test;
@@ -499,6 +499,22 @@ func TestEnum(t *testing.T) {
 export class Holliday {
 	name: string;
 	weekday: Weekday;
+}`
+	testConverter(t, converter, desiredResult)
+}
+
+func TestPTR(t *testing.T) {
+	type Person struct {
+		Name *string `json:"name"`
+	}
+
+	converter := New()
+	converter.CreateFromMethod = false
+	converter.BackupDir = ""
+	converter.Add(Person{})
+
+	desiredResult := `export class Person {
+    name?: string;
 }`
 	testConverter(t, converter, desiredResult)
 }


### PR DESCRIPTION
besides adding `?` to the field name when `omitempty` is present, adds the letter when the field is a pointer type

fixes #29 