### PR TITLE
Add`.ManageType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,23 +240,23 @@ converter.AddImport("import Decimal from 'decimal.js'")
 
 This will put your import on top of the generated file.
 
-Additionally, you can pass optional arguments to `.Add` that map to `ts_type` and `ts_transform`:
+Additionally, you can tell the library to automatically use a given Typescript type and custom transformation for a type:
 
 ```golang
 converter := typescriptify.New()
-converter.Add(time.Time{}, "Date", "new Date(__VALUE__)")
+converter.ManageType(time.Time{}, "Date", "new Date(__VALUE__)")
 ```
 
 This is how now `time.Time` is manage in the library by default.
 
-If you only want to change `ts_transform` but not `ts_type` you can pass an empty string:
+If you only want to change `ts_transform` but not `ts_type`, you can pass an empty string:
 
 ```golang
 converter := typescriptify.New()
-converter.Add(time.Time{}, "", "new Date(__VALUE__)")
+converter.ManageType(time.Time{}, "", "new Date(__VALUE__)")
 ```
 
-Calling `.Add` multiple times with the same type overrides previous additions.
+Calling `.ManageType` multiple times with the same type overrides previous additions.
 
 ## Enums
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ export class Data {
 ```
 
 If the JSON field needs some special handling before converting it to a javascript object, use `ts_transform`.
-For example, Dates can be handles this way:
+For example:
 
 ```golang
 type Data struct {
@@ -239,6 +239,24 @@ converter.AddImport("import Decimal from 'decimal.js'")
 ```
 
 This will put your import on top of the generated file.
+
+Additionally, you can pass optional arguments to `.Add` that map to `ts_type` and `ts_transform`:
+
+```golang
+converter := typescriptify.New()
+converter.Add(time.Time{}, "Date", "new Date(__VALUE__)")
+```
+
+This is how now `time.Time` is manage in the library by default.
+
+If you only want to change `ts_transform` but not `ts_type` you can pass an empty string:
+
+```golang
+converter := typescriptify.New()
+converter.Add(time.Time{}, "", "new Date(__VALUE__)")
+```
+
+Calling `.Add` multiple times with the same type overrides previous additions.
 
 ## Enums
 

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -426,6 +426,11 @@ func (t *TypeScriptify) convertType(typeOf golangType, customCode map[string]str
 		return "", nil
 	}
 
+	// this type is meant to be used as a field only
+	if typeOf.TSType != nil || typeOf.TSTransform != nil {
+		return "", nil
+	}
+
 	t.alreadyConverted[typeOf.Type] = true
 
 	entityName := t.Prefix + typeOf.Type.Name() + t.Suffix

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -369,7 +369,7 @@ func TestTypescriptifyCustomType(t *testing.T) {
 func TestDate(t *testing.T) {
 	t.Parallel()
 	type TestCustomType struct {
-		Time time.Time `json:"time" ts_type:"Date" ts_transform:"new Date(__VALUE__)"`
+		Time time.Time `json:"time"`
 	}
 
 	converter := New()


### PR DESCRIPTION
This PR extends add `.ManageType` allowing developers add their own `ts_type` and `ts_transformation` rules for certain types, useful when you cannot add the tags to fields of third-party structs, like [this one](https://pkg.go.dev/github.com/gbrlsnchs/jwt/v3#Payload).

An existing unit-test, `TestDate`, was modified allowing test of this capability.

Fix #33