### PR TITLE
Minus to underscore in package names

### DIFF
--- a/tscriptify/main.go
+++ b/tscriptify/main.go
@@ -95,6 +95,8 @@ func main() {
 	packageParts := strings.Split(p.ModelsPackage, "/")
 	pckg := packageParts[len(packageParts)-1]
 
+	pckg = strings.Replace(pckg, "-", "_", -1)
+
 	t := template.Must(template.New("").Parse(TEMPLATE))
 
 	filename, err := ioutil.TempDir(os.TempDir(), "")


### PR DESCRIPTION
This works for me.. I often use `-` to separate my github repos, which I suspect my IDE (golang) converts to _ when creating the package name.

Eitherway `-` isn't a valid character so this isn't creating any new failures.