### PR TITLE
Minus to underscore goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,40 @@
+name: Goreleaser
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Set env
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+# .goreleaser.yml
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./tscriptify/main.go
+    id: "tscriptify"
+    binary: tscriptify
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+release:
+  prerelease: auto
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+nfpms:
+  - vendor: base2Services
+    homepage: https://github.com/officeadminsorted/form0-rnd-search-service
+    maintainer: Arran Ubels <a.ubels@base2services.com>
+    description: NA
+    license: Private
+    formats:
+      - apk
+      - deb
+      - rpm
+    release: 1
+    section: default
+    priority: extra

--- a/tscriptify/main.go
+++ b/tscriptify/main.go
@@ -95,6 +95,8 @@ func main() {
 	packageParts := strings.Split(p.ModelsPackage, "/")
 	pckg := packageParts[len(packageParts)-1]
 
+	pckg = strings.Replace(pckg, "-", "_", -1)
+
 	t := template.Must(template.New("").Parse(TEMPLATE))
 
 	filename, err := ioutil.TempDir(os.TempDir(), "")


### PR DESCRIPTION
As part of testing: https://github.com/tkrajina/typescriptify-golang-structs/pull/49 Because it's pretty hard to use go get especially with mods to get a particular branch build it and more. I used 'goreleaser' to build it in a github action. This also causes a publish..

This github action supports tags like follows:
* `v#.#.#` <- Release
* `v#.#.#-*` <-- Pre-release 

(Via:
`.goreleaser.yml`'s)
```yaml
release:
  prerelease: auto
```

