### PR TITLE
Added field that is not annotated with json tag

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -535,6 +535,8 @@ func (t *TypeScriptify) getJSONFieldName(field reflect.StructField, isPtr bool) 
 		if !ignored && isPtr || hasOmitEmpty {
 			jsonFieldName = fmt.Sprintf("%s?", jsonFieldName)
 		}
+	} else if field.IsExported() {
+		jsonFieldName = field.Name
 	}
 	return jsonFieldName
 }

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -968,3 +968,25 @@ export class prefix_Example {
 `
 	testConverter(t, converter, true, desiredResult, nil)
 }
+
+func TestFieldNamesWithoutJSONAnnotation(t *testing.T) {
+	t.Parallel()
+
+	type WithoutAnnotation struct {
+		PublicField  string
+		privateField string
+	}
+
+	converter := New().Add(WithoutAnnotation{})
+	desiredResult := `
+export class WithoutAnnotation {
+    PublicField: string;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.PublicField = source["PublicField"];
+    }
+}
+`
+	testConverter(t, converter, true, desiredResult, nil)
+}


### PR DESCRIPTION
The idea behind this change is that `json.Marshall` will take field's name as it is if no `json` annotation is specified.
So I propose here to keep the same behavior for generated TypeScript types.