### PR TITLE
Skip private structs

### DIFF
--- a/tscriptify/main.go
+++ b/tscriptify/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"text/template"
+	"unicode"
 )
 
 type arrayImports []string
@@ -152,11 +153,19 @@ func (v *AVisitor) Visit(node ast.Node) ast.Visitor {
 	if node != nil {
 		switch t := node.(type) {
 		case *ast.Ident:
-			v.structNameCandidate = t.Name
+			if unicode.IsUpper(rune(t.Name[0])) {
+				v.structNameCandidate = t.Name
+			} else {
+				v.structNameCandidate = ""
+			}
 		case *ast.StructType:
 			if len(v.structNameCandidate) > 0 {
-				v.structs = append(v.structs, v.structNameCandidate)
-				v.structNameCandidate = ""
+				if unicode.IsUpper(rune(v.structNameCandidate[0])) {
+					v.structs = append(v.structs, v.structNameCandidate)
+					v.structNameCandidate = ""
+				} else {
+					v.structNameCandidate = ""
+				}
 			}
 		default:
 			v.structNameCandidate = ""


### PR DESCRIPTION
Trying to access private structs in the parsed Go file causes compile errors in the generated .go file. This checks each struct during the AST's walk to confirm that the structs are exported and thus able to be used.