### PR TITLE
Prevent bogus paths being added

### DIFF
--- a/tscriptify/main.go
+++ b/tscriptify/main.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -101,6 +102,9 @@ func main() {
 	structsArr := make([]string, 0)
 	for _, str := range structs {
 		str = strings.TrimSpace(str)
+		if strings.Contains(str, string(filepath.Separator)) {
+			continue
+		}
 		if len(str) > 0 {
 			structsArr = append(structsArr, "m."+str)
 		}


### PR DESCRIPTION
The following resulted in a path being added with `t.Add(m../my/dir{})`, causing compile-time bugs in the generated Go file:

```
find ./my/dir -name '*.go' -print0 | xargs -0 tscriptify -package mypackage/my/dir -target=file.ts
```

The change ensures that if any struct has a filepath separator, we skip it.