### PR TITLE
Change array check to use `Array.isArray(a)`

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -21,7 +21,7 @@ const (
 	if (!a) {
 		return a;
 	}
-	if (a.slice) {
+	if (Array.isArray(a)) {
 		return (a as any[]).map(elem => this.convertValues(elem, classs));
 	} else if ("object" === typeof a) {
 		if (asMap) {


### PR DESCRIPTION
If `a` is of type string it will match the `if (a.slice) {` condition and fail on the `(a as any[]).map(...)` call as string lacks `a.map` method.
The fix uses `Array.isArray(a)` to prevent such case or any others.