### PR TITLE
Fix missing prefix on map types where value is an array or slice of structs

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -262,8 +262,7 @@ func (t *typeScriptClassBuilder) AddMapField(fieldName string, field reflect.Str
 	if name, ok := t.types[valueType.Kind()]; ok {
 		valueTypeName = name
 	}
-	isArray := valueType.Kind() == reflect.Array || valueType.Kind() == reflect.Slice
-	if isArray {
+	if valueType.Kind() == reflect.Array || valueType.Kind() == reflect.Slice {
 		valueTypeName = valueType.Elem().Name() + "[]"
 	}
 	if valueType.Kind() == reflect.Ptr {
@@ -278,7 +277,7 @@ func (t *typeScriptClassBuilder) AddMapField(fieldName string, field reflect.Str
 	// 	keyTypeStr = t.prefix + keyType.Name() + t.suffix
 	// }
 
-	if valueType.Kind() == reflect.Struct || (isArray && valueType.Elem().Kind() == reflect.Struct) {
+	if valueType.Kind() == reflect.Struct {
 		t.fields = append(t.fields, fmt.Sprintf("%s%s: {[key: %s]: %s};", t.indent, fieldName, keyTypeStr, t.prefix+valueTypeName))
 		t.constructorBody = append(t.constructorBody, fmt.Sprintf("%s%sthis.%s = this.convertValues(source[\"%s\"], %s, true);", t.indent, t.indent, strippedFieldName, strippedFieldName, t.prefix+valueTypeName+t.suffix))
 	} else {

--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -262,7 +262,8 @@ func (t *typeScriptClassBuilder) AddMapField(fieldName string, field reflect.Str
 	if name, ok := t.types[valueType.Kind()]; ok {
 		valueTypeName = name
 	}
-	if valueType.Kind() == reflect.Array || valueType.Kind() == reflect.Slice {
+	isArray := valueType.Kind() == reflect.Array || valueType.Kind() == reflect.Slice
+	if isArray {
 		valueTypeName = valueType.Elem().Name() + "[]"
 	}
 	if valueType.Kind() == reflect.Ptr {
@@ -277,7 +278,7 @@ func (t *typeScriptClassBuilder) AddMapField(fieldName string, field reflect.Str
 	// 	keyTypeStr = t.prefix + keyType.Name() + t.suffix
 	// }
 
-	if valueType.Kind() == reflect.Struct {
+	if valueType.Kind() == reflect.Struct || (isArray && valueType.Elem().Kind() == reflect.Struct) {
 		t.fields = append(t.fields, fmt.Sprintf("%s%s: {[key: %s]: %s};", t.indent, fieldName, keyTypeStr, t.prefix+valueTypeName))
 		t.constructorBody = append(t.constructorBody, fmt.Sprintf("%s%sthis.%s = this.convertValues(source[\"%s\"], %s, true);", t.indent, t.indent, strippedFieldName, strippedFieldName, t.prefix+valueTypeName+t.suffix))
 	} else {

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -1034,3 +1034,32 @@ func TestTypescriptifyCustomJsonTag(t *testing.T) {
 }`
 	testConverter(t, converter, false, desiredResult, nil)
 }
+
+type MapArrayValue struct {
+	Name string `json:"name"`
+}
+type StructWithEnumMapArrayStruct struct {
+	Value  string                     `json:"value"`
+	Values map[string][]MapArrayValue `json:"values"`
+}
+
+func TestTypescriptifyWithStructWithEnumMapArrayStruct(t *testing.T) {
+	t.Parallel()
+	converter := New()
+	converter.Prefix = "test_"
+
+	converter.AddType(reflect.TypeOf(StructWithEnumMapArrayStruct{}))
+	converter.AddType(reflect.TypeOf(MapArrayValue{}))
+	converter.CreateInterface = true
+	converter.CreateConstructor = false
+	converter.BackupDir = ""
+
+	desiredResult := `export interface test_StructWithEnumMapArrayStruct {
+       value: string;
+	   values: {[key: string]: test_MapArrayValue[]};
+	}
+	   export interface test_MapArrayValue {
+	   	name: string;
+		}`
+	testConverter(t, converter, false, desiredResult, nil)
+}

--- a/typescriptify/typescriptify_test.go
+++ b/typescriptify/typescriptify_test.go
@@ -1034,32 +1034,3 @@ func TestTypescriptifyCustomJsonTag(t *testing.T) {
 }`
 	testConverter(t, converter, false, desiredResult, nil)
 }
-
-type MapArrayValue struct {
-	Name string `json:"name"`
-}
-type StructWithEnumMapArrayStruct struct {
-	Value  string                     `json:"value"`
-	Values map[string][]MapArrayValue `json:"values"`
-}
-
-func TestTypescriptifyWithStructWithEnumMapArrayStruct(t *testing.T) {
-	t.Parallel()
-	converter := New()
-	converter.Prefix = "test_"
-
-	converter.AddType(reflect.TypeOf(StructWithEnumMapArrayStruct{}))
-	converter.AddType(reflect.TypeOf(MapArrayValue{}))
-	converter.CreateInterface = true
-	converter.CreateConstructor = false
-	converter.BackupDir = ""
-
-	desiredResult := `export interface test_StructWithEnumMapArrayStruct {
-       value: string;
-	   values: {[key: string]: test_MapArrayValue[]};
-	}
-	   export interface test_MapArrayValue {
-	   	name: string;
-		}`
-	testConverter(t, converter, false, desiredResult, nil)
-}


### PR DESCRIPTION
Given converter with prefix = "test_" and exported types:
```go
type MapArrayValue struct {
	Name string `json:"name"`
}
type StructWithEnumMapArrayStruct struct {
	Value  string                     `json:"value"`
	Values map[string][]MapArrayValue `json:"values"`
}
```
Output misses prefix on nested struct type

```typescript
export interface test_StructWithEnumMapArrayStruct {
  value: string;
  values: {[key: string]: MapArrayValue[]};
}
export interface test_MapArrayValue {
  name: string;
}
```

This PR addresses this edge case and includes unit tests
